### PR TITLE
Implement token reading

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -1,3 +1,4 @@
 module.exports = {
   ALERT_INTERVAL_SEC: 60,
+  TOKENS_FILE: require('path').join(__dirname, '..', 'database', 'tokens.json'),
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 require('dotenv').config();
 const { launchBot } = require('./handlers/telegramHandler');
+const { watchTokens } = require('./services/tokenWatcher');
 
 console.log('Million Accelerator Bot started');
 launchBot();
+watchTokens();

--- a/services/tokenWatcher.js
+++ b/services/tokenWatcher.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const { TOKENS_FILE } = require('../config/settings');
+const { sendAlert } = require('./alertService');
+
+function watchTokens() {
+  let data;
+  try {
+    data = fs.readFileSync(TOKENS_FILE, 'utf8');
+  } catch (err) {
+    console.error(`Не удалось прочитать файл токенов: ${err.message}`);
+    return;
+  }
+
+  let tokens;
+  try {
+    tokens = JSON.parse(data);
+  } catch (err) {
+    console.error(`Некорректный JSON в файле токенов: ${err.message}`);
+    return;
+  }
+
+  if (!Array.isArray(tokens)) {
+    console.error('Файл токенов должен содержать массив объектов');
+    return;
+  }
+
+  tokens.forEach(({ symbol, address }) => {
+    if (!symbol || !address) return;
+    console.log(`${symbol}: ${address}`);
+    sendAlert(`Найден токен: ${symbol} (${address})`);
+  });
+}
+
+module.exports = { watchTokens };
+


### PR DESCRIPTION
## Summary
- add TOKENS_FILE to config
- implement tokenWatcher service
- load token watcher from index.js

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node index.js` *(fails: Bot Token is required)*

------
https://chatgpt.com/codex/tasks/task_e_68601a563c58832199572a2be6c8d3a1