### PR TITLE
Add token growth and volume filters

### DIFF
--- a/services/geckoService.js
+++ b/services/geckoService.js
@@ -12,14 +12,20 @@ async function fetchTokenList() {
       }
     });
 
-    const tokens = response.data.map(token => ({
-      id: token.id,
-      symbol: token.symbol,
-      name: token.name,
-      price: token.current_price,
-      marketCap: token.market_cap,
-      volume: token.total_volume
-    }));
+    const tokens = response.data
+      .filter(token =>
+        token.price_change_percentage_24h > 20 &&
+        token.total_volume > 500000
+      )
+      .map(token => ({
+        id: token.id,
+        symbol: token.symbol,
+        name: token.name,
+        price: token.current_price,
+        marketCap: token.market_cap,
+        volume: token.total_volume,
+        change24h: token.price_change_percentage_24h
+      }));
 
     return tokens;
   } catch (error) {


### PR DESCRIPTION
## Summary
- filter token list from CoinGecko by 24h price growth and trading volume

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68601e501ff88321b7e8f1f5165a2eef