### PR TITLE
Add basic token monitor

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -1,26 +1,20 @@
-const fs = require('fs');
-const { TOKENS_FILE } = require('./config/settings');
-const { sendAlert } = require('./services/alertService');
+const axios = require('axios');
+const { sendTelegramMessage } = require('./telegram');
 
+// Захардкоженные токены (примерные адреса)
+const TOKENS = [
+  { name: 'DEGEN', address: '0xA5E59761eBD4436fa4d20E1A27cBa29FB2471Fc6' },
+  { name: 'PEPE', address: '0x6982508145454Ce325dDbE47a25d4ec3d2311933' }
+];
+
+// Простейший фильтр: "новый токен, объем выше 1000"
 async function analyzeTokens() {
-  let tokens;
-  try {
-    const data = fs.readFileSync(TOKENS_FILE, 'utf8');
-    tokens = JSON.parse(data);
-  } catch (err) {
-    console.error(`Ошибка при чтении токенов: ${err.message}`);
-    return;
-  }
-
-  if (!Array.isArray(tokens)) {
-    console.error('Некорректные данные токенов');
-    return;
-  }
-
-  for (const token of tokens) {
+  for (const token of TOKENS) {
+    // Пример запроса: заглушка
     const isInteresting = Math.random() > 0.5;
+
     if (isInteresting) {
-      await sendAlert(`🔥 Найден интересный токен: ${token.symbol}\n(${token.address})`);
+      await sendTelegramMessage(`🔥 Найден интересный токен: ${token.name}\n(${token.address})`);
     }
   }
 }

--- a/telegram.js
+++ b/telegram.js
@@ -1,0 +1,18 @@
+const axios = require('axios');
+
+async function sendTelegramMessage(text) {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+
+  try {
+    await axios.post(url, {
+      chat_id: chatId,
+      text,
+    });
+  } catch (error) {
+    console.error('Ошибка при отправке сообщения:', error.response?.data || error.message);
+  }
+}
+
+module.exports = { sendTelegramMessage };


### PR DESCRIPTION
## Summary
- add `telegram.js` helper for Telegram alerts
- simplify `monitor.js` to use hard coded tokens and Telegram module

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68602480d02083219185c84b996a7ecd