### PR TITLE
Enable Telegraf webhook launcher

### DIFF
--- a/src/botLauncher.js
+++ b/src/botLauncher.js
@@ -1,0 +1,21 @@
+const { Telegraf } = require('telegraf');
+require('dotenv').config();
+
+const bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);
+
+bot.start((ctx) => ctx.reply('Добро пожаловать в Million Accelerator'));
+bot.command('ping', (ctx) => ctx.reply('pong'));
+
+// Включаем Webhook режим
+bot.launch({
+  webhook: {
+    domain: 'https://million-accelerator-bot.onrender.com',
+    port: process.env.PORT || 10000,
+  },
+});
+
+console.log('🚀 Webhook mode enabled. Bot listening on port', process.env.PORT || 10000);
+
+// Завершаем по сигналу
+process.once('SIGINT', () => bot.stop('SIGINT'));
+process.once('SIGTERM', () => bot.stop('SIGTERM'));


### PR DESCRIPTION
## Summary
- add `src/botLauncher.js` to launch the Telegram bot via webhook instead of polling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860a7a5acb8832193c7332f2ba7220c