### PR TITLE
Add Alchemy WS listener

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 TELEGRAM_BOT_TOKEN=your_token_here
 TELEGRAM_CHAT_ID=your_chat_id_here
 ALCHEMY_KEY=your_alchemy_key_here
+ALCHEMY_WSS=wss://your-alchemy-wss-url

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.env
 node_modules/
+.env

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const express = require('express');
 const bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);
 const app = express();
 const PORT = process.env.PORT || 10000;
+const { startAlchemyListener } = require('./src/alchemyListener');
 
 bot.start((ctx) => ctx.reply('Добро пожаловать в Million Accelerator'));
 bot.command('ping', (ctx) => ctx.reply('pong'));
@@ -13,6 +14,8 @@ bot.command('ping', (ctx) => ctx.reply('pong'));
 bot.launch().then(() => {
   console.log('🤖 Telegram bot started');
 });
+
+startAlchemyListener();
 
 // Заглушка для Render
 app.get('/', (req, res) => {

--- a/src/alchemyListener.js
+++ b/src/alchemyListener.js
@@ -1,0 +1,64 @@
+const WebSocket = require('ws');
+const { sendTelegramMessage } = require('./utils/telegram');
+
+const ALCHEMY_WSS = process.env.ALCHEMY_WSS;
+const DEBUG = process.env.DEBUG_LOG_LEVEL === 'debug';
+
+function logDebug(msg) {
+  if (DEBUG) {
+    console.log(msg);
+  }
+}
+
+function startAlchemyListener() {
+  if (!ALCHEMY_WSS) {
+    console.error('ALCHEMY_WSS is not defined');
+    return;
+  }
+
+  const ws = new WebSocket(ALCHEMY_WSS);
+
+  ws.on('open', () => {
+    logDebug('🛰️ Подключение к Alchemy WebSocket установлено');
+    ws.send(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_subscribe',
+        params: [
+          'alchemy_minedTransactions',
+          {
+            addresses: [],
+            includeRemoved: false,
+            hashesOnly: false,
+          },
+        ],
+      })
+    );
+  });
+
+  ws.on('message', async (data) => {
+    try {
+      const msg = JSON.parse(data);
+      const tx = msg?.params?.result;
+      if (tx) {
+        const text = `💸 Новая транзакция: от ${tx.from} к ${tx.to}, hash: ${tx.hash}`;
+        logDebug(text);
+        await sendTelegramMessage(text);
+      }
+    } catch (err) {
+      console.error('Ошибка обработки события Alchemy:', err.message);
+    }
+  });
+
+  ws.on('close', () => {
+    console.warn('🔌 Соединение с Alchemy закрыто, переподключение через 5с...');
+    setTimeout(startAlchemyListener, 5000);
+  });
+
+  ws.on('error', (err) => {
+    console.error('🚨 Ошибка WebSocket Alchemy:', err.message);
+  });
+}
+
+module.exports = { startAlchemyListener };


### PR DESCRIPTION
## Summary
- ignore node modules correctly
- add ALCHEMY_WSS example entry
- implement `alchemyListener` to subscribe to `alchemy_minedTransactions`
- launch listener from `index.js`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6860b6cbf3148321a26f15dca43ef19d