### PR TITLE
Implement Alchemy spam fix task

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Инфраструктура автоматизации роста криптокапитала — трекер токенов, сигналов, и венчурных циклов",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "run:fixAlchemyTxSpam": "node tasks/fixAlchemyTxSpam.js"
   },
   "keywords": [],
   "author": "",

--- a/tasks/fixAlchemyTxSpam.js
+++ b/tasks/fixAlchemyTxSpam.js
@@ -1,0 +1,65 @@
+/**
+ * Цель: починить спам-ошибку в боте Telegram,
+ * связанную с WebSocket-подпиской Alchemy.
+ */
+
+const WebSocket = require('ws');
+const axios = require('axios');
+require('dotenv').config();
+
+const { sendTelegramMessage } = require('../telegram');
+
+const wsUrl = process.env.ALCHEMY_WSS;
+
+const ws = new WebSocket(wsUrl);
+
+ws.on('open', () => {
+  console.log('[WebSocket] Connected to Alchemy');
+  ws.send(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_subscribe',
+      params: ['alchemy_minedTransactions', { includeRemoved: false, hashesOnly: true }],
+    })
+  );
+});
+
+ws.on('message', async (data) => {
+  try {
+    const parsed = JSON.parse(data);
+    if (parsed.method === 'eth_subscription') {
+      const txHash = parsed.params?.result;
+      if (!txHash || typeof txHash !== 'string') return;
+
+      const response = await axios.post(
+        wsUrl.replace('wss://', 'https://'),
+        {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'eth_getTransactionByHash',
+          params: [txHash],
+        },
+        {
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+
+      const tx = response.data?.result;
+      if (!tx || !tx.from || !tx.to) return;
+
+      const message = `\uD83C\uDF10 Новая транзакция:\nFrom: ${tx.from}\nTo: ${tx.to}\nHash: ${tx.hash}`;
+      await sendTelegramMessage(message);
+    }
+  } catch (err) {
+    console.error('[WebSocket Message Error]', err.message);
+  }
+});
+
+ws.on('close', () => {
+  console.warn('[WebSocket] Closed connection to Alchemy.');
+});
+
+ws.on('error', (err) => {
+  console.error('[WebSocket Error]', err.message);
+});

--- a/tasks/fixAlchemyTxSpam_task.md
+++ b/tasks/fixAlchemyTxSpam_task.md
@@ -1,0 +1,7 @@
+Создать задачу Codex для подключения скрипта фикса спама от Alchemy:
+
+```javascript
+ task("run:fixAlchemyTxSpam")
+   .description("Подключение к Alchemy через WebSocket и фильтрация валидных транзакций")
+   .setScript("tasks/fixAlchemyTxSpam.js")
+```


### PR DESCRIPTION
## Summary
- add a WebSocket script to filter Alchemy mined transactions
- provide Codex task description for running the spam fix
- expose `run:fixAlchemyTxSpam` npm script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860bb38b7c48321bf189ad9f5e8f5cc