### PR TITLE
Add safe Alchemy transaction watcher

### DIFF
--- a/src/tasks/safeAlchemyTxWatcher.js
+++ b/src/tasks/safeAlchemyTxWatcher.js
@@ -1,0 +1,61 @@
+const WebSocket = require('ws');
+const axios = require('axios');
+const { sendTelegramMessage } = require('../utils/telegram');
+require('dotenv').config();
+
+const ALCHEMY_WSS = process.env.ALCHEMY_WSS;
+const DEBUG = process.env.DEBUG_LOG_LEVEL === 'debug';
+
+function logDebug(message) {
+  if (DEBUG) {
+    console.log(message);
+  }
+}
+
+function startSafeAlchemyTxWatcher() {
+  const ws = new WebSocket(ALCHEMY_WSS);
+
+  ws.on('open', () => {
+    logDebug('🔌 WebSocket открыт');
+    const payload = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_subscribe',
+      params: ['alchemy_minedTransactions', { includeRemoved: false }]
+    };
+    ws.send(JSON.stringify(payload));
+  });
+
+  ws.on('message', async (data) => {
+    try {
+      const parsed = JSON.parse(data);
+      const txHash = parsed?.params?.result?.hash;
+      if (!txHash || txHash === 'undefined') return;
+
+      const txDetails = await axios.post(
+        ALCHEMY_WSS.replace('wss', 'https').replace('/v2/', '/v2/'),
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_getTransactionByHash',
+          params: [txHash]
+        },
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+
+      const tx = txDetails?.data?.result;
+      if (!tx || !tx.from || !tx.to) return;
+
+      const message = `📦 Новая транзакция:\nот ${tx.from}\nк ${tx.to}\nhash: ${tx.hash}`;
+      logDebug(message);
+      await sendTelegramMessage(message);
+    } catch (err) {
+      console.error('❌ Ошибка при обработке транзакции:', err.message);
+    }
+  });
+
+  ws.on('close', () => console.warn('❗ WebSocket закрыт, повторное подключение...'));
+  ws.on('error', (err) => console.error('❗ Ошибка WebSocket:', err.message));
+}
+
+module.exports = { startSafeAlchemyTxWatcher };


### PR DESCRIPTION
## Summary
- add a safe transaction watcher task under `src/tasks`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860be91ccac8321b447080e53442938