### PR TITLE
Add safe Alchemy transaction watcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const express = require('express');
 const bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);
 const app = express();
 const PORT = process.env.PORT || 10000;
-const { startAlchemyListener } = require('./src/alchemyListener');
+const { startSafeAlchemyTxWatcher } = require('./src/safeAlchemyTxWatcher');
 
 bot.start((ctx) => ctx.reply('Добро пожаловать в Million Accelerator'));
 bot.command('ping', (ctx) => ctx.reply('pong'));
@@ -15,7 +15,7 @@ bot.launch().then(() => {
   console.log('🤖 Telegram bot started');
 });
 
-startAlchemyListener();
+startSafeAlchemyTxWatcher();
 
 // Заглушка для Render
 app.get('/', (req, res) => {

--- a/src/safeAlchemyTxWatcher.js
+++ b/src/safeAlchemyTxWatcher.js
@@ -1,0 +1,61 @@
+const WebSocket = require('ws');
+const axios = require('axios');
+const { sendTelegramMessage } = require('./utils/telegram');
+require('dotenv').config();
+
+const ALCHEMY_WSS = process.env.ALCHEMY_WSS;
+const DEBUG = process.env.DEBUG_LOG_LEVEL === 'debug';
+
+function logDebug(message) {
+  if (DEBUG) {
+    console.log(message);
+  }
+}
+
+function startSafeAlchemyTxWatcher() {
+  const ws = new WebSocket(ALCHEMY_WSS);
+
+  ws.on('open', () => {
+    logDebug('🔌 WebSocket открыт');
+    const payload = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_subscribe',
+      params: ['alchemy_minedTransactions', { includeRemoved: false }]
+    };
+    ws.send(JSON.stringify(payload));
+  });
+
+  ws.on('message', async (data) => {
+    try {
+      const parsed = JSON.parse(data);
+      const txHash = parsed?.params?.result?.hash;
+      if (!txHash || txHash === 'undefined') return;
+
+      const txDetails = await axios.post(
+        ALCHEMY_WSS.replace('wss', 'https'),
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_getTransactionByHash',
+          params: [txHash]
+        },
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+
+      const tx = txDetails?.data?.result;
+      if (!tx || !tx.from || !tx.to || !tx.hash) return;
+
+      const message = `📦 Новая транзакция:\nот ${tx.from}\nк ${tx.to}\nhash: ${tx.hash}`;
+      logDebug(message);
+      await sendTelegramMessage(message);
+    } catch (err) {
+      console.error('❌ Ошибка при обработке транзакции:', err.message);
+    }
+  });
+
+  ws.on('close', () => console.warn('❗ WebSocket закрыт, повторное подключение...'));
+  ws.on('error', (err) => console.error('❗ Ошибка WebSocket:', err.message));
+}
+
+module.exports = { startSafeAlchemyTxWatcher };


### PR DESCRIPTION
## Summary
- add a new `safeAlchemyTxWatcher` that validates transactions before alerting
- start the new watcher instead of `alchemyListener`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6860c1dc562c8321acd70ccc3db33a20