### PR TITLE
Fix Telegram bot double launch

### DIFF
--- a/handlers/telegramHandler.js
+++ b/handlers/telegramHandler.js
@@ -6,9 +6,16 @@ const bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);
 bot.start((ctx) => ctx.reply('Добро пожаловать в Million Accelerator'));
 bot.command('ping', (ctx) => ctx.reply('pong'));
 
-function launchBot() {
-  bot.launch();
+let isLaunched = false;
+
+function launchBot(options = {}) {
+  if (isLaunched) {
+    console.warn('⚠️ Telegram bot is already running. Ignoring repeated launch.');
+    return;
+  }
+  bot.launch(options);
+  isLaunched = true;
   sendAlert('📢 Бот успешно запущен. Начинаем мониторинг токенов...');
 }
 
-module.exports = { launchBot };
+module.exports = { launchBot, bot };

--- a/index.js
+++ b/index.js
@@ -1,19 +1,13 @@
 require('dotenv').config();
-const { Telegraf } = require('telegraf');
 const express = require('express');
 
-const bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);
 const app = express();
 const PORT = process.env.PORT || 10000;
 const { startErc20Watcher } = require('./handlers/erc20Watcher');
-
-bot.start((ctx) => ctx.reply('Добро пожаловать в Million Accelerator'));
-bot.command('ping', (ctx) => ctx.reply('pong'));
+const { launchBot } = require('./handlers/telegramHandler');
 
 // Запуск Telegram-бота
-bot.launch().then(() => {
-  console.log('🤖 Telegram bot started');
-});
+launchBot();
 
 startErc20Watcher();
 

--- a/src/botLauncher.js
+++ b/src/botLauncher.js
@@ -1,21 +1,19 @@
-const { Telegraf } = require('telegraf');
-require('dotenv').config();
+const { launchBot } = require('../handlers/telegramHandler');
 
-const bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);
+function launchWebhookBot() {
+  launchBot({
+    webhook: {
+      domain: 'https://million-accelerator-bot.onrender.com',
+      port: process.env.PORT || 10000,
+    },
+  });
 
-bot.start((ctx) => ctx.reply('Добро пожаловать в Million Accelerator'));
-bot.command('ping', (ctx) => ctx.reply('pong'));
+  console.log(
+    '🚀 Webhook mode enabled. Bot listening on port',
+    process.env.PORT || 10000,
+  );
 
-// Включаем Webhook режим
-bot.launch({
-  webhook: {
-    domain: 'https://million-accelerator-bot.onrender.com',
-    port: process.env.PORT || 10000,
-  },
-});
+  // Graceful shutdown is handled inside Telegraf once launched
+}
 
-console.log('🚀 Webhook mode enabled. Bot listening on port', process.env.PORT || 10000);
-
-// Завершаем по сигналу
-process.once('SIGINT', () => bot.stop('SIGINT'));
-process.once('SIGTERM', () => bot.stop('SIGTERM'));
+module.exports = { launchWebhookBot };


### PR DESCRIPTION
## Summary
- centralize Telegraf bot start logic in `handlers/telegramHandler`
- expose webhook launcher via `src/botLauncher`
- use the shared launcher from `index.js`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866bd87cdbc832186f7de0b93867813