### PR TITLE
Add Pump Profit Sniper strategy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ TELEGRAM_BOT_TOKEN=your_token_here
 TELEGRAM_CHAT_ID=your_chat_id_here
 ALCHEMY_KEY=your_alchemy_key_here
 ALCHEMY_WSS=wss://your-alchemy-wss-url
+PUMP_PROFIT_THRESHOLD_VOLUME=200
+PUMP_PROFIT_THRESHOLD_PRICE=20

--- a/config/settings.js
+++ b/config/settings.js
@@ -1,5 +1,11 @@
+const path = require('path');
+
 module.exports = {
   ALERT_INTERVAL_SEC: 60,
-  TOKENS_FILE: require('path').join(__dirname, '..', 'database', 'tokens.json'),
+  TOKENS_FILE: path.join(__dirname, '..', 'database', 'tokens.json'),
   MIN_TX_USD: 10000,
+  PUMP_PROFIT_THRESHOLD_VOLUME:
+    Number(process.env.PUMP_PROFIT_THRESHOLD_VOLUME) || 200,
+  PUMP_PROFIT_THRESHOLD_PRICE:
+    Number(process.env.PUMP_PROFIT_THRESHOLD_PRICE) || 20,
 };

--- a/src/strategies/pumpProfitSniper.js
+++ b/src/strategies/pumpProfitSniper.js
@@ -1,0 +1,31 @@
+const settings = require('../../config/settings');
+const { sendTelegramAlert } = require('../utils/telegram');
+const { saveToHistory } = require('../utils/historyLogger');
+
+function checkPumpSignal(tokenData) {
+  if (!tokenData) return false;
+  const {
+    symbol = 'Unknown',
+    priceChangePercent = 0,
+    volumeChangePercent = 0,
+  } = tokenData;
+
+  const priceOk = priceChangePercent >= settings.PUMP_PROFIT_THRESHOLD_PRICE;
+  const volumeOk = volumeChangePercent >= settings.PUMP_PROFIT_THRESHOLD_VOLUME;
+
+  if (priceOk && volumeOk) {
+    const message = `🚀 Всплеск активности!\nТокен: ${symbol}\nЦена: +${priceChangePercent}% | Объём: +${volumeChangePercent}%\nВозможен памп — проверь на DEX!`;
+    sendTelegramAlert(message);
+    saveToHistory({
+      timestamp: new Date().toISOString(),
+      type: 'PumpProfitSniper',
+      token: symbol,
+      priceChange: priceChangePercent,
+      volumeChange: volumeChangePercent,
+    });
+    return true;
+  }
+  return false;
+}
+
+module.exports = { checkPumpSignal };

--- a/src/utils/telegram.js
+++ b/src/utils/telegram.js
@@ -15,4 +15,8 @@ async function sendTelegramMessage(message) {
   }
 }
 
-module.exports = { sendTelegramMessage };
+async function sendTelegramAlert(message) {
+  await sendTelegramMessage(message);
+}
+
+module.exports = { sendTelegramMessage, sendTelegramAlert };

--- a/telegram.js
+++ b/telegram.js
@@ -15,4 +15,8 @@ async function sendTelegramMessage(text) {
   }
 }
 
-module.exports = { sendTelegramMessage };
+async function sendTelegramAlert(message) {
+  await sendTelegramMessage(message);
+}
+
+module.exports = { sendTelegramMessage, sendTelegramAlert };


### PR DESCRIPTION
## Summary
- introduce Pump Profit Sniper strategy
- add telegram alert helper
- expose pump threshold config
- check for price & volume spikes in token monitor
- document env vars

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866c4faf2908321be7fcfaed410a9e7