### PR TITLE
Implement Unlock Risk Tracker

### DIFF
--- a/config/settings.js
+++ b/config/settings.js
@@ -31,4 +31,9 @@ module.exports = {
   NEWS_ALARM_THRESHOLD: Number(process.env.NEWS_ALARM_THRESHOLD) || 3,
   NEWS_SPAM_INTERVAL_MINUTES:
     Number(process.env.NEWS_SPAM_INTERVAL_MINUTES) || 30,
+  UNLOCK_LOOKAHEAD_DAYS: Number(process.env.UNLOCK_LOOKAHEAD_DAYS) || 7,
+  UNLOCK_MIN_PERCENT: Number(process.env.UNLOCK_MIN_PERCENT) || 1.0,
+  UNLOCK_MIN_USD: Number(process.env.UNLOCK_MIN_USD) || 1_000_000,
+  UNLOCK_SPAM_INTERVAL_HOURS:
+    Number(process.env.UNLOCK_SPAM_INTERVAL_HOURS) || 24,
 };

--- a/src/strategies/unlockRiskTracker.js
+++ b/src/strategies/unlockRiskTracker.js
@@ -1,0 +1,101 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+const settings = require('../../config/settings');
+const { sendTelegramAlert } = require('../utils/telegram');
+
+const DEBUG = process.env.DEBUG_LOG_LEVEL === 'debug';
+function logDebug(msg) {
+  if (DEBUG) console.log(msg);
+}
+
+const SEEN_PATH = path.join(__dirname, '..', '..', 'storage', 'unlocksSeen.json');
+
+function loadSeen() {
+  try {
+    if (fs.existsSync(SEEN_PATH)) {
+      return JSON.parse(fs.readFileSync(SEEN_PATH, 'utf8'));
+    }
+  } catch (err) {
+    console.error('Failed to read unlock history:', err.message);
+  }
+  return {};
+}
+
+function saveSeen(data) {
+  try {
+    fs.mkdirSync(path.dirname(SEEN_PATH), { recursive: true });
+    fs.writeFileSync(SEEN_PATH, JSON.stringify(data, null, 2));
+  } catch (err) {
+    console.error('Failed to write unlock history:', err.message);
+  }
+}
+
+async function fetchUpcomingUnlocks() {
+  const url = 'https://token.unlocks.app/api/v1/upcoming';
+  try {
+    const res = await axios.get(url, {
+      params: { days: settings.UNLOCK_LOOKAHEAD_DAYS },
+      headers: { 'User-Agent': 'Mozilla/5.0' },
+    });
+    const raw = Array.isArray(res.data?.data) ? res.data.data : res.data || [];
+    return raw.map((e) => ({
+      id: e.id || `${e.symbol}-${e.date}`,
+      symbol: e.symbol || e.token,
+      date: e.date || e.timestamp,
+      usd: parseFloat(e.usdAmount || e.amountUsd || e.valueUsd || 0),
+      percent: parseFloat(e.percent || e.percentOfCirculation || 0),
+      source: 'TokenUnlocks',
+    }));
+  } catch (err) {
+    console.error('Failed to fetch unlock info:', err.message);
+    return [];
+  }
+}
+
+function daysUntil(dateStr) {
+  const now = Date.now();
+  const target = new Date(dateStr).getTime();
+  return Math.ceil((target - now) / (24 * 60 * 60 * 1000));
+}
+
+async function checkUnlocks() {
+  const events = await fetchUpcomingUnlocks();
+  if (!events.length) return;
+
+  const seen = loadSeen();
+  const now = Date.now();
+  let updated = false;
+
+  for (const ev of events) {
+    if (isNaN(ev.percent) && isNaN(ev.usd)) continue;
+    if (
+      ev.percent >= settings.UNLOCK_MIN_PERCENT ||
+      ev.usd >= settings.UNLOCK_MIN_USD
+    ) {
+      const last = seen[ev.id] || 0;
+      if (now - last >= settings.UNLOCK_SPAM_INTERVAL_HOURS * 60 * 60 * 1000) {
+        const days = daysUntil(ev.date);
+        const usdFmt = `$${(ev.usd / 1_000_000).toFixed(1)}M`;
+        const msg =
+          `⚠️ Разлок токена $${ev.symbol} через ${days} дня\n` +
+          `Объем: ${usdFmt} (${ev.percent.toFixed(1)}% от циркуляции)\n` +
+          `Платформа: ${ev.source}\n` +
+          '→ Возможен дамп. Рассмотри фиксацию или отложи покупку.';
+        logDebug(`Unlock alert for ${ev.symbol}`);
+        await sendTelegramAlert(msg);
+        seen[ev.id] = now;
+        updated = true;
+      }
+    }
+  }
+
+  if (updated) saveSeen(seen);
+}
+
+function startUnlockRiskTracker() {
+  checkUnlocks();
+  setInterval(checkUnlocks, 6 * 60 * 60 * 1000);
+}
+
+module.exports = { startUnlockRiskTracker, fetchUpcomingUnlocks, checkUnlocks };


### PR DESCRIPTION
## Summary
- track upcoming token unlocks
- keep a history of alerts so each unlock is only signaled once a day
- add settings for unlock monitoring

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686a2b4b342c83219ae848b74022eb1d