### PR TITLE
Implement report scheduler service

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,13 @@ const app = express();
 const PORT = process.env.PORT || 10000;
 const { startErc20Watcher } = require('./handlers/erc20Watcher');
 const { launchBot } = require('./handlers/telegramHandler');
+const { startReportScheduler } = require('./reportScheduler');
 
 // Запуск Telegram-бота
 launchBot();
 
 startErc20Watcher();
+startReportScheduler();
 
 // Заглушка для Render
 app.get('/', (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.10.0",
         "dotenv": "^17.0.0",
         "express": "^5.1.0",
+        "node-cron": "^3.0.2",
         "node-fetch": "^3.3.2",
         "rss-parser": "^3.13.0",
         "telegraf": "^4.16.3",
@@ -780,6 +781,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.2.tgz",
+      "integrity": "sha512-iP8l0yGlNpE0e6q1o185yOApANRe47UPbLf4YxfbiNHt/RU5eBcGB/e0oudruheSf+LQeDMezqC5BVAb5wwRcQ==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -1256,6 +1269,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "axios": "^1.10.0",
     "dotenv": "^17.0.0",
     "express": "^5.1.0",
+    "node-cron": "^3.0.2",
     "node-fetch": "^3.3.2",
     "rss-parser": "^3.13.0",
     "telegraf": "^4.16.3",

--- a/reportScheduler.js
+++ b/reportScheduler.js
@@ -1,0 +1,111 @@
+const cron = require('node-cron');
+const fs = require('fs');
+const path = require('path');
+const { sendTelegramMessage } = require('./telegram');
+
+const DEBUG = process.env.DEBUG_LOG_LEVEL === 'debug';
+function logDebug(msg) {
+  if (DEBUG) console.log(msg);
+}
+
+const PATHS = {
+  profitHistory: path.join(__dirname, 'history', 'profitHistory.json'),
+  positions: path.join(__dirname, 'data', 'positions.json'),
+  comboSignals: path.join(__dirname, 'logs', 'comboSignals.json'),
+  capital: path.join(__dirname, 'data', 'capital.json'),
+  freshIdeas: path.join(__dirname, 'signals', 'freshIdeas.json'),
+  sentiment: path.join(__dirname, 'signals', 'sentimentScanner.json'),
+  reportsDir: path.join(__dirname, 'history', 'reports'),
+};
+
+function loadJson(file, def = []) {
+  try {
+    if (fs.existsSync(file)) {
+      const data = fs.readFileSync(file, 'utf8');
+      return JSON.parse(data);
+    }
+  } catch (err) {
+    console.error(`Failed to read ${path.basename(file)}:`, err.message);
+  }
+  return def;
+}
+
+function saveReport(period, report) {
+  try {
+    fs.mkdirSync(PATHS.reportsDir, { recursive: true });
+    const file = path.join(PATHS.reportsDir, `${period}.json`);
+    fs.writeFileSync(file, JSON.stringify(report, null, 2));
+  } catch (err) {
+    console.error('Failed to save report:', err.message);
+  }
+}
+
+function buildReport(period) {
+  const profitHistory = loadJson(PATHS.profitHistory);
+  const positions = loadJson(PATHS.positions);
+  const combo = loadJson(PATHS.comboSignals);
+  const capital = loadJson(PATHS.capital, {});
+  const ideas = loadJson(PATHS.freshIdeas);
+  const sentiment = loadJson(PATHS.sentiment);
+
+  const daysMap = { weekly: 7, monthly: 30, quarterly: 90, semiannual: 182, yearly: 365 };
+  const days = daysMap[period] || 7;
+  const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+
+  const entries = profitHistory.filter(p => new Date(p.timestamp || p.date || 0).getTime() >= cutoff);
+  let profit = 0;
+  if (entries.length >= 2) {
+    const start = entries[0].totalCapitalUSD;
+    const end = entries[entries.length - 1].totalCapitalUSD;
+    if (start && end) profit = (end - start) / start;
+  }
+
+  const newSignals = combo.filter(c => new Date(c.date || 0).getTime() >= cutoff).length;
+
+  return {
+    date: new Date().toISOString(),
+    period,
+    profit,
+    positions: positions.length,
+    newSignals,
+    ideas: ideas.length,
+    sentimentRecords: sentiment.length,
+    capital,
+  };
+}
+
+async function sendReport(period) {
+  const report = buildReport(period);
+  saveReport(period, report);
+
+  let message = `\uD83D\uDCC8 Отчёт за ${period}\n`;
+  if (report.profit) {
+    const pct = (report.profit * 100).toFixed(2);
+    message += `Доходность: ${report.profit >= 0 ? '+' : ''}${pct}%\n`;
+  } else {
+    message += 'Доходность: нет данных\n';
+  }
+  message += `Открытых позиций: ${report.positions}\n`;
+  if (report.newSignals)
+    message += `Новые комбо-сигналы: ${report.newSignals}\n`;
+  if (report.ideas)
+    message += `Свежие идеи: ${report.ideas}\n`;
+  logDebug(message.trim());
+  await sendTelegramMessage(message.trim());
+}
+
+function startReportScheduler() {
+  const cronMap = {
+    weekly: '0 9 * * 1',
+    monthly: '0 10 1 * *',
+    quarterly: '0 11 1 1,4,7,10 *',
+    semiannual: '0 12 1 1,7 *',
+    yearly: '0 13 1 1 *',
+  };
+  Object.entries(cronMap).forEach(([period, expr]) => {
+    cron.schedule(expr, () => sendReport(period));
+  });
+  logDebug('Report scheduler started');
+}
+
+module.exports = { startReportScheduler };


### PR DESCRIPTION
## Summary
- add automated reporting via `reportScheduler.js`
- call new scheduler from `index.js`
- include `node-cron` dependency

## Testing
- `npm ls node-cron`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686a39c12e4883218b36cd8dbdcd521f