### PR TITLE
Integrate automatic token selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ const { startErc20Watcher } = require('./handlers/erc20Watcher');
 const { launchBot } = require('./handlers/telegramHandler');
 const { startReportScheduler } = require('./reportScheduler');
 const { start: startSmartDeploymentManager } = require('./smartDeploymentManager');
+const { selectTopTokens, startSelector } = require('./src/monitoring/topTokenSelector');
+const { startScheduledTokenScan } = require('./src/services/tokenScanner');
 
 // Запуск Telegram-бота
 launchBot();
@@ -14,6 +16,15 @@ launchBot();
 startErc20Watcher();
 startReportScheduler();
 startSmartDeploymentManager();
+
+(async () => {
+  const tokens = await selectTopTokens();
+  if (!tokens.length) {
+    console.warn('[INIT] ⚠️ Список токенов пуст.');
+  }
+  startScheduledTokenScan(tokens);
+  startSelector();
+})();
 
 // Заглушка для Render
 app.get('/', (req, res) => {

--- a/src/monitoring/topTokenSelector.js
+++ b/src/monitoring/topTokenSelector.js
@@ -140,7 +140,11 @@ async function selectTopTokens() {
   }
 
   logDebug('No tokens selected - returning cached list');
-  return loadCachedTokens();
+  const cached = loadCachedTokens();
+  if (!cached.length) {
+    console.warn('[TOP-TOKENS] ⚠️ Пустой список токенов.');
+  }
+  return cached;
 }
 
 function startSelector() {

--- a/src/services/tokenScanner.js
+++ b/src/services/tokenScanner.js
@@ -35,7 +35,7 @@ async function startTokenScanCycle(tokens = defaultTokens) {
   }
 }
 
-function startScheduledTokenScan() {
+function startScheduledTokenScan(initialTokens) {
   console.log('[SCHEDULER] ⏳ Запускаем отложенный анализ токенов...');
   const run = async () => {
     if (isScanning) {
@@ -43,13 +43,16 @@ function startScheduledTokenScan() {
       return;
     }
 
-    let tokens = [];
-    try {
-      // eslint-disable-next-line global-require
-      tokens = require('../../data/top-tokens.json');
-    } catch (err) {
-      console.error('[SCHEDULER] ❌ Ошибка загрузки токенов:', err.message);
-      return;
+    let tokens = Array.isArray(initialTokens) ? initialTokens : [];
+    initialTokens = null;
+    if (!tokens.length) {
+      try {
+        // eslint-disable-next-line global-require
+        tokens = require('../../data/top-tokens.json');
+      } catch (err) {
+        console.error('[SCHEDULER] ❌ Ошибка загрузки токенов:', err.message);
+        return;
+      }
     }
 
     if (!tokens.length) {


### PR DESCRIPTION
## Summary
- wire up token selector and scanner in the main entry
- warn when token selection returns an empty list
- allow token scanner to accept initial token list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686acd8275188321945c6cf2689553f3