### PR TITLE
Implement top token selection and scan cycle

### DIFF
--- a/database/tokens.json
+++ b/database/tokens.json
@@ -1,10 +1,1 @@
-[
-  {
-    "symbol": "PEPE",
-    "address": "0x6982508145454Ce325dDbE47a25d4ec3d2311933"
-  },
-  {
-    "symbol": "DEGEN",
-    "address": "0xA5E59761eBD4436fa4d20E1A27cBa29FB2471Fc6"
-  }
-]
+[]

--- a/monitor.js
+++ b/monitor.js
@@ -3,11 +3,8 @@ const { sendTelegramMessage, sendTelegramAlert } = require('./telegram');
 const { checkPumpSignal } = require('./src/strategies/pumpProfitSniper');
 const settings = require('./config/settings');
 
-// Токены для мониторинга
-const TOKENS = [
-  { name: 'PEPE', address: '0x6982508145454Ce325dDbE47a25d4ec3d2311933' },
-  { name: 'DEGEN', address: '0xA5E59761eBD4436fa4d20E1A27cBa29FB2471Fc6' },
-];
+// Токены для мониторинга (можно заполнить адресами при необходимости)
+const TOKENS = [];
 
 // Проверяем объем торгов через Dexscreener
 async function analyzeTokens() {

--- a/src/monitoring/topTokenSelector.js
+++ b/src/monitoring/topTokenSelector.js
@@ -67,8 +67,7 @@ function loadBlacklist() {
 
 async function fetchDexTokens() {
   try {
-    const url =
-      'https://api.dexscreener.com/latest/dex/tokens?chain=base';
+    const url = 'https://api.dexscreener.com/latest/dex/tokens';
     const { data } = await fetchWithRetry(url);
     return data.pairs || data;
   } catch (err) {
@@ -118,8 +117,15 @@ async function selectTopTokens() {
   for (const t of dexTokens) {
     if (result.length >= MAX_TOKENS) break;
     const address = t?.baseToken?.address?.toLowerCase();
-    if (!address) continue;
-    if (t.chainId && t.chainId.toLowerCase() !== 'base') continue;
+    if (!address || address.startsWith('0x0000000000000000000000000000000000000000')) {
+      continue;
+    }
+    if (
+      t.chainId &&
+      !['eth', 'ethereum', 'bsc'].includes(t.chainId.toLowerCase())
+    ) {
+      continue;
+    }
     if (blacklist.has(address)) {
       logDebug(`Skip ${address} - blacklisted`);
       continue;


### PR DESCRIPTION
## Summary
- filter tokens from DexScreener for ETH and BSC networks
- avoid placeholder contracts and store addresses in `data/top-tokens.json`
- load token list without duplicates and start scans only when tokens exist
- remove demo tokens from repository

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686b74a1f3188321a21a8d245861f9e8