### PR TITLE
Fix DexScreener API URL

### DIFF
--- a/monitor.js
+++ b/monitor.js
@@ -10,10 +10,10 @@ const TOKENS = [];
 async function analyzeTokens() {
   for (const token of TOKENS) {
     try {
-      const url = `https://api.dexscreener.com/latest/dex/tokens/${token.address}`;
-      const res = await axios.get(url);
-
-      const data = res.data.pairs?.[0];
+      const res = await axios.get('https://api.dexscreener.com/latest/dex/pairs');
+      const data = res.data.pairs.find(
+        (p) => p.baseToken.address.toLowerCase() === token.address.toLowerCase()
+      );
       if (!data) continue;
 
       const volume24h = parseFloat(data.volume?.h24Usd || 0);

--- a/src/monitoring/topTokenSelector.js
+++ b/src/monitoring/topTokenSelector.js
@@ -72,7 +72,7 @@ function loadBlacklist() {
 
 async function fetchDexTokens() {
   try {
-    const url = 'https://api.dexscreener.com/latest/dex/tokens';
+    const url = 'https://api.dexscreener.com/latest/dex/pairs';
     const { data } = await fetchWithRetry(url);
     return data.pairs || data;
   } catch (err) {


### PR DESCRIPTION
## Summary
- use new /latest/dex/pairs endpoint in monitor
- update URL in topTokenSelector

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686c03a026908321bb678eeb9ca06143